### PR TITLE
デザイン修正を行いやすくするために、各記事に id を適用できるようにしたい

### DIFF
--- a/yasslab/Rakefile
+++ b/yasslab/Rakefile
@@ -42,6 +42,7 @@ task :refine_html do
     # Change title to include chapters
     html.at_css('h1').prepend_child "<span class='number'>第#{sec_number}章</span>"
     html.at_css('.site')['id'] = file_name
+    html.at_css('.site').add_class('textbook-content')
 
     html.css('#home .posts a').each do |a|
       href = a.attr('href')

--- a/yasslab/Rakefile
+++ b/yasslab/Rakefile
@@ -41,6 +41,7 @@ task :refine_html do
 
     # Change title to include chapters
     html.at_css('h1').prepend_child "<span class='number'>第#{sec_number}章</span>"
+    html.at_css('.site')['id'] = file_name
 
     html.css('#home .posts a').each do |a|
       href = a.attr('href')


### PR DESCRIPTION
🎫 https://github.com/yasslab/railstutorial.jp_web/issues/3984#issuecomment-749928066

## やったこと

> https://github.com/yasslab/railstutorial.jp_web/issues/3984 の対応をしたいのですが、`<div class="site">`あたりの要素に`id="textbook_cover"`のようにRailsの教科書専用のidをつけることはできますか？
>  https://idobata.io/archives/messages/35399667#message_35399667