### PR TITLE
head 情報は Railsチュートリアルの部分で表示するので削除

### DIFF
--- a/yasslab/Rakefile
+++ b/yasslab/Rakefile
@@ -36,8 +36,8 @@ task :refine_html do
     file = File.open("_site/#{file_name}.html")
     html = Nokogiri::HTML(file, nil, 'utf-8')
 
-    html.css('.header').remove
-    html.search('link[rel=stylesheet]').remove
+    html.search('.header').remove
+    html.search('head').remove
 
     # Change title to include chapters
     html.at_css('h1').prepend_child "<span class='number'>第#{sec_number}章</span>"


### PR DESCRIPTION
🎫 close: https://github.com/yasslab/railstutorial.jp_web/issues/3989

## やったこと

head 情報が body に入っていると、HTML の読み込みをした際に影響があるので、コンテンツ部分にある head 情報を削除した