### PR TITLE
学習ガイドとRailsガイドの書籍のリンクを変更したい

### DIFF
--- a/_posts/2016-02-17-postface.md
+++ b/_posts/2016-02-17-postface.md
@@ -45,16 +45,14 @@ GitとGitHubをGUIアプリから使う方法をマンガ形式で分かりや�
 Railsを学びはじめると、Webサービスにはたくさんの技術が使われていることに気づきます。いま学んでいるこの技術は全体の中でどんな位置づけなんだろう？次は何を学べばいいのだろう？「RubyとRailsの学習ガイド」はRubyそしてRailsを学ぶ旅のガイドブックです。技術を学び、戻ってくるたびにレベルアップする、Webサービスを作る技術者の冒険の旅をサポートする地図です。各技術を学ぶための資料や書籍の情報を書いています。
 
 - RubyとRailsの学習ガイド 2019 技術書典6 拡大版
-  - 五十嵐邦明 著 [https://igaigarb.booth.pm/](https://igaigarb.booth.pm/)
+  - 五十嵐邦明 著 [http://railstutorial.jp/guidebook](http://railstutorial.jp/guidebook)
+
 
 ### Railsを学ぶ資料
 
 本書ではRailsの基礎の仕組みを説明し、簡単なアプリを作って、アプリを作る上での基本的なデバッグ作業を説明してきました。
 
 さらにRailsの理解を深めたい方には、以下の資料や書籍をお薦めします。
-
-- Ruby と Railsの学習ガイド
-  - [http://railstutorial.jp/guidebook](http://railstutorial.jp/guidebook)
 
 - Ruby on Rails ガイド
   - [https://railsguides.jp](https://railsguides.jp)
@@ -63,7 +61,6 @@ Railsの各機能を網羅的に解説しているサイトです。Railsの機�
 
 - Ruby on Rails チュートリアル
   - [https://railstutorial.jp](https://railstutorial.jp)
-  - 電子書籍版 [https://tatsu-zine.com/books/railstutorial](https://tatsu-zine.com/books/railstutorial)
 
 Railsアプリを作りながら学ぶWeb上の資料です。Railsを学ぶ初期の資料として定番のものです。実際にアプリを作りながら知識を深めたいという方へお勧めです。
 

--- a/_posts/2016-02-17-postface.md
+++ b/_posts/2016-02-17-postface.md
@@ -53,9 +53,11 @@ Railsを学びはじめると、Webサービスにはたくさんの技術が使
 
 さらにRailsの理解を深めたい方には、以下の資料や書籍をお薦めします。
 
+- Ruby と Railsの学習ガイド
+  - [http://railstutorial.jp/guidebook](http://railstutorial.jp/guidebook)
+
 - Ruby on Rails ガイド
   - [https://railsguides.jp](https://railsguides.jp)
-  - 電子書籍版 [https://tatsu-zine.com/books/railsguides](https://tatsu-zine.com/books/railsguides)
 
 Railsの各機能を網羅的に解説しているサイトです。Railsの機能の使い方が分からないときに最初にあたるサイトでもあります。調べ物で使うのも良いですが、一度通読しておくとどのような機能があるかを把握できてその後の進みが速いです。常に最新のRailsについての記述が書いてあるサイトでもあります。本書でも各章の最後に、その章の内容に該当するRailsガイドへのリンクを書いているのでぜひ読んでみてください。
 
@@ -66,7 +68,7 @@ Railsの各機能を網羅的に解説しているサイトです。Railsの機�
 Railsアプリを作りながら学ぶWeb上の資料です。Railsを学ぶ初期の資料として定番のものです。実際にアプリを作りながら知識を深めたいという方へお勧めです。
 
 - 現場で使える Ruby on Rails 5 速習実践ガイド
-  - 株式会社万葉 監修 マイナビ出版 ISBN: 978-4839962227 
+  - 株式会社万葉 監修 マイナビ出版 ISBN: 978-4839962227
 
 Railsの基礎知識を広く学べる、通称『現場Rails』と呼ばれる書籍です。Railsの基礎を網羅的に説明しています。Railsの受託開発や開発支援を長年つづけている株式会社万葉のみなさんが執筆されているので、タイトル通り現場で使える技術に即した内容です。Rails5.2対応。
 


### PR DESCRIPTION
🎫 close: https://github.com/yasslab/railstutorial.jp_web/issues/3999

### やること

- Ruby と Railsの学習ガイドは自社のページへリンクを変更
- 削除する✂️: 電子書籍版 https://tatsu-zine.com/books/railstutorial

![image](https://user-images.githubusercontent.com/48109243/102975101-e231ba80-4542-11eb-93d1-0e0727067555.png)
